### PR TITLE
chore: add `repository` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-workflows",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple state machine workflow implementation for JS",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/types/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dworzycp/js-workflows.git"
+  },
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
Adds `repository` to `package.json` to be displayed on the npm page.